### PR TITLE
Support filtering variant dependencies from build reqs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 dependencies = [
   "packaging >= 19.1",
   "pyproject_hooks",
-  "variantlib @ https://github.com/mgorny/variantlib/archive/env-spec.tar.gz",
+  "variantlib @ https://github.com/wheelnext/variantlib/archive/main.tar.gz",
   # not actually a runtime dependency, only supplied as there is not "recommended dependency" support
   'colorama; os_name == "nt"',
   'importlib-metadata >= 4.6; python_full_version < "3.10.2"',  # Not required for 3.8+, but fixes a stdlib bug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = ["version"]
 dependencies = [
   "packaging >= 19.1",
   "pyproject_hooks",
+  "variantlib @ https://github.com/mgorny/variantlib/archive/env-spec.tar.gz",
   # not actually a runtime dependency, only supplied as there is not "recommended dependency" support
   'colorama; os_name == "nt"',
   'importlib-metadata >= 4.6; python_full_version < "3.10.2"',  # Not required for 3.8+, but fixes a stdlib bug

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -132,9 +132,12 @@ def _build_in_isolated_env(
     with DefaultIsolatedEnv(installer=installer) as env:
         builder = ProjectBuilder.from_isolated_env(env, srcdir)
         # first install the build dependencies
-        env.install(builder.build_system_requires)
+        env.install(builder.filter_variants(builder.build_system_requires, config_settings or {}))
         # then get the extra required dependencies from the backend (which was installed in the call above :P)
-        env.install(builder.get_requires_for_build(distribution, config_settings or {}))
+        env.install(builder.filter_variants(
+            builder.get_requires_for_build(distribution, config_settings or {}),
+            config_settings or {}
+        ))
         return builder.build(distribution, outdir, config_settings or {})
 
 

--- a/src/build/util.py
+++ b/src/build/util.py
@@ -45,8 +45,8 @@ def project_wheel_metadata(
                 source_dir,
                 runner=runner,
             )
-            env.install(builder.build_system_requires)
-            env.install(builder.get_requires_for_build('wheel'))
+            env.install(builder.filter_variants(builder.build_system_requires))
+            env.install(builder.filter_variants(builder.get_requires_for_build('wheel')))
             return _project_wheel_metadata(builder)
     else:
         builder = ProjectBuilder(


### PR DESCRIPTION
xref: https://github.com/wheelnext/variantlib/pull/32

The idea is that e.g. in numpy we can do:

```toml
[build-system]
build-backend = "mesonpy"
requires = [
    "meson-python @ https://github.com/mgorny/meson-python/archive/wheel-variants.tar.gz",
    "Cython>=3.0.6",  # keep in sync with version check in meson.build
    "variant_x86_64 @ https://github.com/wheelnext/variant_x86_64/archive/main.tar.gz ; 'x86_64' in variants"
]
```

And `build` uses `variantlib` to preprocess the `'x86_64' in variants` specifier, so that uv/pip can handle the resulting deps. Not saying the design is neat, but should be good enough for a demo.